### PR TITLE
Add download progress information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # LazyFetcher
+[![Build Status](https://dev.azure.com/rhdpin/rhdpin/_apis/build/status/rhdpin.lazyfetcher?branchName=master)](https://dev.azure.com/rhdpin/rhdpin/_build/latest?definitionId=1&branchName=master)
 
 Download [LazyMan](https://github.com/StevensNJD4/LazyMan) streams from command line. 
 
@@ -6,10 +7,10 @@ Download [LazyMan](https://github.com/StevensNJD4/LazyMan) streams from command 
 * Download the latest game of given team
 * Get the stream URL to be used by a video player
 
-The application is still very basic with fixed settings. See also similar (Rust made) application, [LazyStream](https://github.com/tarkah/lazystream), which is more configurable, but doesn't support downloading yet. 
+The application is still very basic with fixed settings and supports NHL feeds. See also similar (Rust made) application, [LazyStream](https://github.com/tarkah/lazystream). 
 
 ## Requirements 
-* OS: Windows (x86/x64)/ MacOS / Linux (x64/ARMv7)
+* OS: Windows (x86/x64) / MacOS / Linux (x64/ARMv7)
 * [.NET Core 3.0](https://dotnet.microsoft.com/download/dotnet-core/3.0) runtime (and SDK if also building)
 * [Streamlink](https://github.com/streamlink/streamlink)
 * [go-mlbam-proxy](https://github.com/jwallet/go-mlbam-proxy)
@@ -18,56 +19,45 @@ The application is still very basic with fixed settings. See also similar (Rust 
 You can install the [Streamlink](https://github.com/streamlink/streamlink) according to its installation instructions. [go-mlbam-proxy](https://github.com/jwallet/go-mlbam-proxy) executable (mlbamproxy.exe) can also be copied from LazyMan installation. Both Streamlink and and go-mlbam-proxy must be either in same directory with LazyFetch executable, or in directory specified by PATH environment variable.
 
 ## Usage
-Get latest game of your favorite team. It tries to get feed of chosen team (away/home) if available, otherwise it uses first feed found.
-```
-$ ./LazyFetcher -t CAR -p /mnt/download
-LazyFetcher 1.0.0.0
-
-Fetching latest feed for 'car'...
-Feed found: 2019-12-12 CAR@VAN (away,FS-CR)
-
-[cli][info] Found matching plugin hls for URL hlsvariant://http://foundurl.m3u8 name_key=bitrate verify=False
-[cli][info] Available streams: 670k (worst), 1000k, 1450k, 2140k, 2900k, 4100k, 6600k (best)
-[cli][info] Opening stream: 6600k (hls)
-[download][..12-12-CAR@VAN-FS-CR.mp4] Written 235.5 MB (32s @ 6.5 MB/s) 
-```
 Choose the feed from list of found feeds
 ```
 $ ./LazyFetcher -c
 LazyFetcher 1.0.0.0
 
- 1: 2019-12-12 NSH@BUF home (MSG-B)
- 2: 2019-12-12 NSH@BUF away (FS-TN)
- 3: 2019-12-12 BOS@TBL home (SUN)
- 4: 2019-12-12 BOS@TBL away (NESN)
- 5: 2019-12-12 NYI@FLA home (FS-F)
- 6: 2019-12-12 NYI@FLA away (MSG+)
- 7: 2019-12-12 CBJ@PIT home (ATT-PT)
- 8: 2019-12-12 CBJ@PIT away (FSOH)
- 9: 2019-12-12 WPG@DET home (FS-D+)
-10: 2019-12-12 WPG@DET away (TSN3)
-11: 2019-12-12 VGK@STL home (FSMW)
-12: 2019-12-12 VGK@STL away (ATT-RM)
-13: 2019-12-12 EDM@MIN home (FS-N)
-14: 2019-12-12 EDM@MIN away (SNOL)
-15: 2019-12-12 TOR@CGY home (SNW)
-16: 2019-12-12 TOR@CGY away (TSN4)
-17: 2019-12-12 CHI@ARI home (FSAZ)
-18: 2019-12-12 CHI@ARI away (NBCS-CH)
-19: 2019-12-12 CAR@VAN home (SNP)
-20: 2019-12-12 CAR@VAN away (FS-CR)
-21: 2019-12-12 LAK@ANA home (PRIME)
-22: 2019-12-12 LAK@ANA away (FS-W)
-23: 2019-12-12 NYR@SJS home (NBCS-CA)
-24: 2019-12-12 NYR@SJS away (MSG)
-25: 2019-12-13 VGK@DAL home (FSSW)
-26: 2019-12-13 VGK@DAL away (ATT-RM)
-27: 2019-12-13 NJD@COL home (ALT)
-28: 2019-12-13 NJD@COL away (MSG+)
+ 1: 2019-12-15 PHI@WPG home (TSN3)
+ 2: 2019-12-15 PHI@WPG away (NBCS-PH+)
+ 3: 2019-12-15 MIN@CHI home (NBCS-CH)
+ 4: 2019-12-15 MIN@CHI away (FS-N)
+ 5: 2019-12-15 LAK@DET home (FS-D)
+ 6: 2019-12-15 LAK@DET away (FS-W)
+ 7: 2019-12-15 VAN@VGK home (ATT-RM)
+ 8: 2019-12-15 VAN@VGK national (SN)
+ 9: 2019-12-16 OTT@FLA home (FS-F)
+10: 2019-12-16 OTT@FLA away (TSN5)
+11: 2019-12-16 NSH@NYR home (MSG)
+12: 2019-12-16 NSH@NYR away (FS-TN)
+13: 2019-12-16 WSH@CBJ home (FSOH)
+14: 2019-12-16 WSH@CBJ away (NBCS-WA)
+15: 2019-12-16 COL@STL home (FSMW)
+16: 2019-12-16 COL@STL away (ALT)
+17: 2019-12-16 EDM@DAL home (FSSW+)
+18: 2019-12-16 EDM@DAL away (SNW)
 
-Choose feed (q to quit): 
+Choose feed (q to quit): 11
+
+Downloading feed: 2019-12-16 NSH@NYR (home,MSG)
+Writing stream to file: 167 MB (11.8 MB/s)
+```
+Get latest game of your favorite team. It tries to get feed of chosen team (away/home) if available, otherwise it uses first feed found.
+```
+$ ./LazyFetcher -t DAL -p /mnt/download
+LazyFetcher 1.0.0.0
+
+Fetching latest feed for 'DAL'...
+Feed found: 2019-12-16 EDM@DAL (home,FSSW+)
+Writing stream to file: 343 MB (8.2 MB/s)
 ```
 ## Releases
 Windows releases contain only the app itself, so [.NET Core runtime](https://dotnet.microsoft.com/download/dotnet-core/3.0) needs to be installed. 
 
-Ubuntu and Linux (ARMv7) releases have also the needed .NET Core binaries, so the size is bigger but no need to install .NET Core separately. After extracting the files on Linux, run `chmod +x LazyFetcher` to make the program executable.
+Ubuntu and Linux (ARMv7) releases have also the needed .NET Core binaries, so the size is bigger but no need to install .NET Core separately. After extracting the files on Linux, run `chmod +x LazyFetcher` to make the program executable. MacOS binaries are coming soon.

--- a/README.md
+++ b/README.md
@@ -7,11 +7,10 @@ Download [LazyMan](https://github.com/StevensNJD4/LazyMan) streams from command 
 * Download the latest game of given team
 * Get the stream URL to be used by a video player
 
-The application is still very basic with fixed settings and supports NHL feeds. See also similar (Rust made) application, [LazyStream](https://github.com/tarkah/lazystream). 
+The application ([.NET Core 3.0](https://dotnet.microsoft.com/download/dotnet-core/3.0)) is still very basic with fixed settings and supports NHL feeds. See also similar (Rust made) application, [LazyStream](https://github.com/tarkah/lazystream). 
 
 ## Requirements 
 * OS: Windows (x86/x64) / MacOS / Linux (x64/ARMv7)
-* [.NET Core 3.0](https://dotnet.microsoft.com/download/dotnet-core/3.0) runtime (and SDK if also building)
 * [Streamlink](https://github.com/streamlink/streamlink)
 * [go-mlbam-proxy](https://github.com/jwallet/go-mlbam-proxy)
 
@@ -58,6 +57,6 @@ Feed found: 2019-12-16 EDM@DAL (home,FSSW+)
 Writing stream to file: 343 MB (8.2 MB/s)
 ```
 ## Releases
-Windows releases contain only the app itself, so [.NET Core runtime](https://dotnet.microsoft.com/download/dotnet-core/3.0) needs to be installed. 
+All release packages contain all needed files, so no additional installation of .NET Core runtime is needed. 
 
-Ubuntu and Linux (ARMv7) releases have also the needed .NET Core binaries, so the size is bigger but no need to install .NET Core separately. After extracting the files on Linux, run `chmod +x LazyFetcher` to make the program executable. MacOS binaries are coming soon.
+After extracting the files on Linux, run `chmod +x LazyFetcher` to make the program executable. MacOS binaries are coming soon.

--- a/src/Downloader/StreamlinkDownloader.cs
+++ b/src/Downloader/StreamlinkDownloader.cs
@@ -61,7 +61,7 @@ namespace LazyFetcher.Downloader
             var streamUrl = request.StreamUrl.Replace("https://", "http://");
 
             // Uses fixed stream quality (="best")
-            var streamArgs = $"\"hlsvariant://{streamUrl} name_key=bitrate verify=False\" 670k --http-header " +
+            var streamArgs = $"\"hlsvariant://{streamUrl} name_key=bitrate verify=False\" best --http-header " +
                                 $"\"User-Agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) " +
                                 $"Chrome/59.0.3071.115 Safari/537.36\" --hls-segment-threads=4 {proxyString} -o {request.TargetFileName}";
 

--- a/src/FeedManager.cs
+++ b/src/FeedManager.cs
@@ -44,7 +44,7 @@ namespace LazyFetcher
                 return;
             }
 
-            Console.WriteLine($"\nDownloading feed: {chosenFeed.Date} {chosenFeed.Away}@{chosenFeed.Home} ({chosenFeed.Type},{chosenFeed.Name})\n\n");
+            Console.WriteLine($"\nDownloading feed: {chosenFeed.Date} {chosenFeed.Away}@{chosenFeed.Home} ({chosenFeed.Type},{chosenFeed.Name})");
 
             Download(streamUrl, chosenFeed, targetPath);
         }
@@ -66,7 +66,7 @@ namespace LazyFetcher
                 return;
             }
 
-            Console.WriteLine($"Feed found: {feed.Date} {feed.Away}@{feed.Home} ({feed.Type},{feed.Name})\n");
+            Console.WriteLine($"Feed found: {feed.Date} {feed.Away}@{feed.Home} ({feed.Type},{feed.Name})");
 
             Download(streamUrl, feed, targetPath);
         }               

--- a/src/FeedManager.cs
+++ b/src/FeedManager.cs
@@ -44,7 +44,7 @@ namespace LazyFetcher
                 return;
             }
 
-            Console.WriteLine($"\nDownloading feed: {chosenFeed.Date} {chosenFeed.Away}@{chosenFeed.Home} ({chosenFeed.Type},{chosenFeed.Name})\n");
+            Console.WriteLine($"\nDownloading feed: {chosenFeed.Date} {chosenFeed.Away}@{chosenFeed.Home} ({chosenFeed.Type},{chosenFeed.Name})\n\n");
 
             Download(streamUrl, chosenFeed, targetPath);
         }


### PR DESCRIPTION
Adds download progress information. Due to issues with handling standard output from Streamlink, I decided to make my own progress info implementation. It checks the file size and calculates the download rate. All unexpected Streamlink output is added in console output in the end.

The result looks cleaner than the output of Streamlink.

Fixes PR #1  