### PR TITLE
App expects hosts file to be edited by default, proxy behind a parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,37 @@ The application ([.NET Core 3.0](https://dotnet.microsoft.com/download/dotnet-co
 ## Requirements 
 * OS: Windows (x86/x64) / MacOS / Linux (x64/ARMv7)
 * [Streamlink](https://github.com/streamlink/streamlink)
-* [go-mlbam-proxy](https://github.com/jwallet/go-mlbam-proxy)
+* Application expects that by default that hosts file has been configure for needed redirection. Alternatively a parameter can be used to use [go-mlbam-proxy](https://github.com/jwallet/go-mlbam-proxy) instead.
 
 ## Installation
-You can install the [Streamlink](https://github.com/streamlink/streamlink) according to its installation instructions. [go-mlbam-proxy](https://github.com/jwallet/go-mlbam-proxy) executable (mlbamproxy.exe) can also be copied from LazyMan installation. Both Streamlink and and go-mlbam-proxy must be either in same directory with LazyFetch executable, or in directory specified by PATH environment variable.
+You can install the [Streamlink](https://github.com/streamlink/streamlink) according to its installation instructions. If hosts file is not edited, [go-mlbam-proxy](https://github.com/jwallet/go-mlbam-proxy) is needed. The executable (mlbamproxy.exe) can also be copied from LazyMan installation. Both Streamlink (and go-mlbam-proxy if needed) must be either in same directory with LazyFetch executable, or in directory specified by PATH environment variable.
 
 ## Usage
-Choose the feed from list of found feeds
 ```
-$ ./LazyFetcher -c
+$ ./LazyFetcher --help
+LazyFetcher 1.0.1
+Copyright (C) 2019 rhdpin
+
+  -c, --choose       Choose the feed from list of found feeds.
+
+  -t, --team         Get latest game for team (three letter abbreviation. E.g. WPG).
+
+  -p, --path         Set target download path.
+
+  -l, --league       Set league (default: NHL).
+
+  -u, --url          Get only URL of the stream but don't download.
+
+  -x, --use-proxy    Use proxy for redirection (required if 'hosts' file has not been edited).
+
+  --help             Display this help screen.
+
+  --version          Display version information.
+```
+
+Choose the feed from list of found feeds and download it using proxy instead of editing hosts file
+```
+$ ./LazyFetcher -x -c -p /mnt/download
 LazyFetcher 1.0.1
 
  1: 2019-12-15 PHI@WPG home (TSN3)
@@ -47,7 +69,7 @@ Choose feed (q to quit): 11
 Downloading feed: 2019-12-16 NSH@NYR (home,MSG)
 Writing stream to file: 167 MB (11.8 MB/s)
 ```
-Get latest game of your favorite team. It tries to get feed of chosen team (away/home) if available, otherwise it uses first feed found.
+Get latest game of your favorite team with hosts file edited. It tries to get feed of chosen team (away/home) if available, otherwise it uses first feed found.
 ```
 $ ./LazyFetcher -t DAL -p /mnt/download
 LazyFetcher 1.0.1

--- a/src/Data/DownloadRequest.cs
+++ b/src/Data/DownloadRequest.cs
@@ -1,11 +1,12 @@
 ﻿
+using LazyFetcher.Interface;
+
 namespace LazyFetcher.Data
 {
     public class DownloadRequest
     {
         public string StreamUrl { get; set; }
         public string TargetFileName { get; set; }
-        public bool IsProxyRequired { get; set; }
-        public int ProxyPort { get; set; }
+        public IProxy Proxy { get; set; }
     }
 }

--- a/src/Downloader/StreamlinkDownloader.cs
+++ b/src/Downloader/StreamlinkDownloader.cs
@@ -53,9 +53,9 @@ namespace LazyFetcher.Downloader
             }
 
             var proxyString = string.Empty;
-            if (request.IsProxyRequired)
+            if (request.Proxy != null)
             {
-                proxyString = $"--https-proxy https://127.0.0.1:{request.ProxyPort}";
+                proxyString = $"--https-proxy https://127.0.0.1:{request.Proxy.Port}";
             }
 
             var streamUrl = request.StreamUrl.Replace("https://", "http://");
@@ -122,6 +122,7 @@ namespace LazyFetcher.Downloader
             _process.WaitForExit();
             Console.WriteLine();
 
+            var unexpectedOutput = false;
             // Write Streamlink output to console (other than the regular messages)
             while (!_process.StandardOutput.EndOfStream)
             {
@@ -129,9 +130,17 @@ namespace LazyFetcher.Downloader
 
                 if (line != null && !line.StartsWith("[cli][info]") && !line.Contains("[download]"))
                 {
-                    Console.WriteLine($"{line}");                    
+                    Console.WriteLine($"{line}");
+                    unexpectedOutput = true;
                 }
-            }            
+            }  
+            
+            if (unexpectedOutput)
+            {
+                Console.WriteLine("\nLooks like something went wrong. Please check that redirection is configured either by editing " +
+                    "hosts file or by using proxy (parameter '-x' and requires that mlbamproxy is found). " +
+                    "By default application expects that hosts file is edited");
+            }
         }
     }
 }

--- a/src/FeedManager.cs
+++ b/src/FeedManager.cs
@@ -26,7 +26,7 @@ namespace LazyFetcher
             {
                 Console.WriteLine($"{feed.Id.ToString().PadLeft(2)}: {feed.Date} {feed.Away}@{feed.Home} {feed.Type} ({feed.Name})");
             }
-
+            
             Console.Write("\nChoose feed (q to quit): ");
             var input = Console.ReadLine();
 
@@ -34,7 +34,7 @@ namespace LazyFetcher
             {
                 return;
             }
-
+            
             var chosenFeed = feeds.FirstOrDefault(f => f.Id == int.Parse(input));
             var streamUrl = urlFetcher.GetStreamUrl(chosenFeed);
 
@@ -75,10 +75,12 @@ namespace LazyFetcher
         {
             var fileName = GetTargetFileName(feed, targetPath);
             var league = Program.IocContainer.GetInstance<ILeague>();
+            var options = Program.IocContainer.GetInstance<IOptions>();
+
             IProxy proxy = null;
             try
             {
-                if (league.IsProxyRequired)
+                if (options.UseProxy && league.IsRedirectionRequired)
                 {
                     proxy = Program.IocContainer.GetInstance<IProxy>();
                     if (!proxy.Start())
@@ -86,7 +88,7 @@ namespace LazyFetcher
                         return;
                     }
                 }
-                var downloadRequest = new DownloadRequest() { IsProxyRequired = league.IsProxyRequired, ProxyPort = proxy.Port, StreamUrl = streamUrl, TargetFileName = fileName };
+                var downloadRequest = new DownloadRequest() { Proxy = proxy, StreamUrl = streamUrl, TargetFileName = fileName };
                 var downloader = Program.IocContainer.GetInstance<IDownloader>();
                 downloader.Download(downloadRequest);
             }

--- a/src/Interface/ILeague.cs
+++ b/src/Interface/ILeague.cs
@@ -8,7 +8,7 @@ namespace LazyFetcher.Interface
     public interface ILeague
     {
         string Name { get; }
-        bool IsProxyRequired { get; }
+        bool IsRedirectionRequired { get; }
         Type ProxyType { get; }
         LeagueType Type { get; }
     }

--- a/src/Interface/IOptions.cs
+++ b/src/Interface/IOptions.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace LazyFetcher.Interface
+{
+    public interface IOptions
+    {
+        bool Choose { get; set; }
+                
+        string TargetPath { get; set; }
+
+        string Team { get; set; }
+
+        string League { get; set; }
+
+        bool OnlyUrl { get; set; }
+
+        bool UseProxy { get; set; }
+    }
+}

--- a/src/NHL/NHLLeague.cs
+++ b/src/NHL/NHLLeague.cs
@@ -9,7 +9,7 @@ namespace LazyFetcher.NHL
     public class NHLLeague : ILeague
     {
         public string Name => "NHL";
-        public bool IsProxyRequired => true;
+        public bool IsRedirectionRequired => true;
         public Type ProxyType => typeof(NHLProxy);
         public LeagueType Type => LeagueType.NHL;
     }

--- a/src/Options.cs
+++ b/src/Options.cs
@@ -1,22 +1,26 @@
 ﻿using CommandLine;
+using LazyFetcher.Interface;
 
 namespace LazyFetcher
 {
-    public class Options
+    public class Options : IOptions
     {
-        [Option('c', "choose", Required = false, HelpText = "Choose the feed from list of found feeds.")]
+        [Option('c', "choose", SetName = "choose", Required = false, HelpText = "Choose the feed from list of found feeds.")]
         public bool Choose { get; set; }
+
+        [Option('t', "team", SetName = "team", Required = false, HelpText = "Get latest game for team (three letter abbreviation. E.g. WPG).")]
+        public string Team { get; set; }
 
         [Option('p', "path", Required = false, HelpText = "Set target download path.")]
         public string TargetPath { get; set; }
-
-        [Option('t', "team", Required = false, HelpText = "Get latest game for team (three letter abbreviation. E.g. WPG).")]
-        public string Team { get; set; }
-
+        
         [Option('l', "league", Required = false, HelpText = "Set league (default: NHL).")]
         public string League { get; set; }
 
-        [Option('u', "url", Required = false, HelpText = "Get only URL of the stream but don't download")]
+        [Option('u', "url", Required = false, HelpText = "Get only URL of the stream but don't download.")]
         public bool OnlyUrl { get; set; }
+
+        [Option('x', "use-proxy", Required = false, HelpText = "Use proxy for redirection (required if 'hosts' file has not been edited).")]
+        public bool UseProxy { get; set; }
     }
 }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -63,6 +63,8 @@ namespace LazyFetcher
                 Parser.Default.ParseArguments<Options>(args)
                     .WithParsed<Options>(options =>
                     {
+                        IocContainer.Register<IOptions>(factory => options);
+
                         if (options.Team != null)
                         {
                             feedManager.GetLatest(options.Team, options.TargetPath, options.OnlyUrl);


### PR DESCRIPTION
Proxy usage must be enabled by using parameter '-x' or '--use-proxy'. Without that parameters app expects that hosts file has been edited. It also means that mlbamproxy is not necessarily required anymore.

Adds app options to IOC container so that they're easier to use anywhere (also beneficial for future options). 

Fixes issue #3.