### PR TITLE
Fix issue in proxy usage handling (#7)

### DIFF
--- a/src/Data/DownloadRequest.cs
+++ b/src/Data/DownloadRequest.cs
@@ -7,6 +7,6 @@ namespace LazyFetcher.Data
     {
         public string StreamUrl { get; set; }
         public string TargetFileName { get; set; }
-        public IProxy Proxy { get; set; }
+        public bool UseProxy { get; set; }
     }
 }

--- a/src/DefaultFeedManager.cs
+++ b/src/DefaultFeedManager.cs
@@ -108,7 +108,7 @@ namespace LazyFetcher
                         return;
                     }
                 }
-                var downloadRequest = new DownloadRequest() { Proxy = _proxy, StreamUrl = streamUrl, TargetFileName = fileName };
+                var downloadRequest = new DownloadRequest() { UseProxy = _options.UseProxy, StreamUrl = streamUrl, TargetFileName = fileName };
                 _downloader.Download(downloadRequest);
             }
             finally

--- a/src/Downloader/StreamlinkDownloader.cs
+++ b/src/Downloader/StreamlinkDownloader.cs
@@ -15,11 +15,13 @@ namespace LazyFetcher.Downloader
         private Process _process = null;
         private readonly IMessenger _messenger;
         private readonly IOptions _options;
+        private readonly IProxy _proxy;
 
-        public StreamlinkDownloader(IMessenger messenger, IOptions options)
+        public StreamlinkDownloader(IMessenger messenger, IOptions options, IProxy proxy)
         {
             _messenger = messenger;
             _options = options;
+            _proxy = proxy;
         }
 
         public void Dispose()
@@ -61,9 +63,9 @@ namespace LazyFetcher.Downloader
             }
 
             var proxyString = string.Empty;
-            if (request.Proxy != null)
-            {
-                proxyString = $"--https-proxy https://127.0.0.1:{request.Proxy.Port}";
+            if (request.UseProxy)
+            {                
+                proxyString = $"--https-proxy https://127.0.0.1:{_proxy.Port}";
             }
 
             var streamUrl = request.StreamUrl.Replace("https://", "http://");                    


### PR DESCRIPTION
A bug caused proxy to be used even when it was not to be used. Now the proxy is injected to StreamlinkDownloader using constructor injection and DownloadRequest contains only boolean describing if proxy is to be used or not.