### PR TITLE
Publish using GitHub actions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,7 +2,7 @@ name: Publish
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   release:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,8 +8,7 @@ on:
 
 jobs:
 
-  build:
-
+  x64:
     runs-on: ubuntu-latest
 
     steps:    
@@ -25,6 +24,14 @@ jobs:
       run: docker build . --file linux-x64.Dockerfile --tag rhdpin/lazyfetcher:linux-x64
     - name: Push the latest Docker image for linux-x64
       run: docker push rhdpin/lazyfetcher:linux-x64
+
+  arm:
+    runs-on: self-hosted
+
+    steps:    
+    - uses: actions/checkout@v2
+    - name: Login to DockerHub Registry
+      run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin    
 
     - name: Build the tagged Docker image for linux-arm
       run: docker build . --file linux-arm.Dockerfile --tag rhdpin/lazyfetcher:1.0.5-linux-arm32v7

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,7 +2,7 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ docker ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -49,11 +49,11 @@ jobs:
         # Delete output directory
         rm -r "$release_name"
     - name: Publish
-        uses: softprops/action-gh-release@v1
-        with:
-          files: "LazyFetcher*"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: softprops/action-gh-release@v1
+      with:
+        files: "LazyFetcher*"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     
     #- name: Test

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -21,12 +21,13 @@ jobs:
       run: dotnet publish -c release -r linux-x64 src/       
     - name: Build win10-x64
       run: dotnet publish -c release -r win10-x64 src/     
-    - name: Echo
-      run: echo $(pwd)
+    - name: Build osx.10.15-x64
+      run: dotnet publish -c release -r osx.10.15-x64 src/        
     - name: Zip
       run: |
-        zip -r linux-x64.zip src/bin/Release/netcoreapp3.1/linux-x64/publish
+        tar -czvf linux-x64.zip src/bin/Release/netcoreapp3.1/linux-x64/publish
         zip -r win10-x64.zip src/bin/Release/netcoreapp3.1/win10-x64/publish
+        zip -r osx.10.15-x64.zip src/bin/Release/netcoreapp3.1/osx.10.15-x64/publish
     - uses: actions/upload-artifact@v2
       with:
         name: linux-x64
@@ -35,6 +36,10 @@ jobs:
       with:
         name: win10-x64
         path: win10-x64.zip
+    - uses: actions/upload-artifact@v2
+      with:
+        name: osx.10.15-x64
+        path: osx.10.15-x64.zip
   publish-linux-arm:
     runs-on: self-hosted
     steps:
@@ -42,11 +47,9 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore src/
     - name: Build
-      run: dotnet publish -c release -r linux-arm src/       
-    - name: Echo
-      run: echo $(pwd)
+      run: dotnet publish -c release -r linux-arm src/           
     - name: Zip
-      run: zip -r linux-arm.zip src/bin/Release/netcoreapp3.1/linux-arm/publish
+      run: tar -czvf -r linux-arm.zip src/bin/Release/netcoreapp3.1/linux-arm/publish
     - uses: actions/upload-artifact@v2
       with:
         name: linux-arm

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,14 +1,29 @@
-name: Docker Image CI
+name: Publish
 
 on:
-  push:
-    branches: [ docker ]
-  pull_request:
-    branches: [ master ]
+  release:
+    types: [created]
 
 jobs:
-  publish-linux-x64:
-    runs-on: ubuntu-latest
+  release:
+    name: Release
+    strategy:
+      matrix: 
+        kind: ['linux-arm', 'linux-x64', 'windows', 'macOS']
+        include:
+          - kind: linux-arm
+            os: self-hosted
+            target: linux-arm
+          - kind: linux-x64
+            os: ubuntu-latest
+            target: linux-x64
+          - kind: windows
+            os: windows-latest
+            target: win-x64
+          - kind: macOS
+            os: macos-latest
+            target: osx-x64
+    runs-on: ${{ matrix.os }}  
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET
@@ -17,43 +32,30 @@ jobs:
         dotnet-version: 5.0.x
     - name: Restore dependencies
       run: dotnet restore src/
-    - name: Build linux-x64
-      run: dotnet publish -c release -r linux-x64 src/       
-    - name: Build win10-x64
-      run: dotnet publish -c release -r win10-x64 src/     
-    - name: Build osx.10.15-x64
-      run: dotnet publish -c release -r osx.10.15-x64 src/        
-    - name: Zip
-      run: |
-        tar -czvf linux-x64.zip src/bin/Release/netcoreapp3.1/linux-x64/publish
-        zip -r win10-x64.zip src/bin/Release/netcoreapp3.1/win10-x64/publish
-        zip -r osx.10.15-x64.zip src/bin/Release/netcoreapp3.1/osx.10.15-x64/publish
-    - uses: actions/upload-artifact@v2
-      with:
-        name: linux-x64
-        path: linux-x64.zip
-    - uses: actions/upload-artifact@v2
-      with:
-        name: win10-x64
-        path: win10-x64.zip
-    - uses: actions/upload-artifact@v2
-      with:
-        name: osx.10.15-x64
-        path: osx.10.15-x64.zip
-  publish-linux-arm:
-    runs-on: self-hosted
-    steps:
-    - uses: actions/checkout@v2    
-    - name: Restore dependencies
-      run: dotnet restore src/
     - name: Build
-      run: dotnet publish -c release -r linux-arm src/           
-    - name: Zip
-      run: tar -czvf linux-arm.zip src/bin/Release/netcoreapp3.1/linux-arm/publish
-    - uses: actions/upload-artifact@v2
-      with:
-        name: linux-arm
-        path: linux-arm.zip
+        shell: bash
+        run: |
+          tag=$(git describe --tags --abbrev=0)
+          release_name="LazyFetcher-${{ matrix.target }}"
+          # Build everything
+          dotnet publish src/ --runtime "${{ matrix.target }}" -c Release -o "$release_name"
+          # Pack files
+          if [ "${{ matrix.target }}" == "win-x64" ]; then
+            # Pack to zip for Windows
+            7z a -tzip "${release_name}.zip" "./${release_name}/*"
+          else
+          tar czvf "${release_name}.tar.gz" "$release_name"
+          fi
+          # Delete output directory
+          rm -r "$release_name"
+    - name: Publish
+        uses: softprops/action-gh-release@v1
+        with:
+          files: "LazyFetcher*"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    
     #- name: Test
     #  run: dotnet test --no-build --verbosity normal
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -21,6 +21,8 @@ jobs:
       run: dotnet restore src/
     - name: Build
       run: dotnet publish -c release -r linux-x64 src/       
+    - name: Echo
+      run: echo $(pwd)
     - name: Zip
       run: zip linux-x64.zip src/bin/Release/netcoreapp3.1/linux-x64/publish
     - uses: actions/upload-artifact@v2

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,10 +7,8 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
-
+  publish-linux-x64:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET
@@ -19,16 +17,40 @@ jobs:
         dotnet-version: 5.0.x
     - name: Restore dependencies
       run: dotnet restore src/
-    - name: Build
+    - name: Build linux-x64
       run: dotnet publish -c release -r linux-x64 src/       
+    - name: Build win10-x64
+      run: dotnet publish -c release -r win10-x64 src/     
     - name: Echo
       run: echo $(pwd)
     - name: Zip
-      run: zip -r linux-x64.zip src/bin/Release/netcoreapp3.1/linux-x64/publish
+      run: |
+        zip -r linux-x64.zip src/bin/Release/netcoreapp3.1/linux-x64/publish
+        zip -r win10-x64.zip src/bin/Release/netcoreapp3.1/win10-x64/publish
     - uses: actions/upload-artifact@v2
       with:
-        name: linux.x64
+        name: linux-x64
         path: linux-x64.zip
+    - uses: actions/upload-artifact@v2
+      with:
+        name: win10-x64
+        path: win10-x64.zip
+  publish-linux-arm:
+    runs-on: self-hosted
+    steps:
+    - uses: actions/checkout@v2    
+    - name: Restore dependencies
+      run: dotnet restore src/
+    - name: Build
+      run: dotnet publish -c release -r linux-arm src/       
+    - name: Echo
+      run: echo $(pwd)
+    - name: Zip
+      run: zip -r linux-arm.zip src/bin/Release/netcoreapp3.1/linux-arm/publish
+    - uses: actions/upload-artifact@v2
+      with:
+        name: linux-arm
+        path: linux-arm.zip
     #- name: Test
     #  run: dotnet test --no-build --verbosity normal
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -80,9 +80,9 @@ jobs:
         tag=$(git describe --tags --abbrev=0)
         docker_file_name=""
         if [ "${{ matrix.target }}" == "linux-x64" ]; then
-            $docker_file_name = "linux-x64.Dockerfile"
+            $docker_file_name="linux-x64.Dockerfile"
           else
-            $docker_file_name = "linux-arm.Dockerfile"
+            $docker_file_name="linux-arm.Dockerfile"
           fi
         docker build . --file $docker_file_name --tag "rhdpin/lazyfetcher:$tag-${{ matrix.kind }}"
         docker push "rhdpin/lazyfetcher:$tag-${{ matrix.kind }}""

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -85,9 +85,9 @@ jobs:
             docker_file_name="linux-arm.Dockerfile"
           fi
         docker build . --file $docker_file_name --tag "rhdpin/lazyfetcher:$tag-${{ matrix.kind }}"
-        docker push "rhdpin/lazyfetcher:$tag-${{ matrix.kind }}""
-        docker build . --file $docker_file_name --tag "rhdpin/lazyfetcher:${{ matrix.kind }}""
-        docker push "rhdpin/lazyfetcher:${{ matrix.kind }}""   
+        docker push "rhdpin/lazyfetcher:$tag-${{ matrix.kind }}"
+        docker build . --file $docker_file_name --tag "rhdpin/lazyfetcher:${{ matrix.kind }}"
+        docker push "rhdpin/lazyfetcher:${{ matrix.kind }}"
 
 
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -20,7 +20,11 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore src/
     - name: Build
-      run: dotnet build --no-restore src/
+      run: dotnet publish -c release -r linux-x64 src/       
+    - uses: actions/upload-artifact@v2
+      with:
+        name: x64-binaries
+        path: src/**/linux-x64
     #- name: Test
     #  run: dotnet test --no-build --verbosity normal
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Push the tagged Docker image
       run: docker push rhdpin/lazyfetcher:1.0.5-linux-x64
     - name: Build the latest Docker image
-      run: docker build . --file Dockerfile --tag rhdpin/lazyfetcher:linux-x64
+      run: docker build . --file linux-x64.Dockerfile --tag rhdpin/lazyfetcher:linux-x64
     - name: Push the latest Docker image
       run: docker push rhdpin/lazyfetcher:linux-x64
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -80,13 +80,13 @@ jobs:
         tag=$(git describe --tags --abbrev=0)
         docker_file_name=""
         if [ "${{ matrix.target }}" == "linux-x64" ]; then
-            docker_file_name = "linux-x64.Dockerfile"
+            $docker_file_name = "linux-x64.Dockerfile"
           else
-            docker_file_name = "linux-arm.Dockerfile"
+            $docker_file_name = "linux-arm.Dockerfile"
           fi
-        docker build . --file "$docker_file_name" --tag "rhdpin/lazyfetcher:$tag-${{ matrix.kind }}"
+        docker build . --file $docker_file_name --tag "rhdpin/lazyfetcher:$tag-${{ matrix.kind }}"
         docker push "rhdpin/lazyfetcher:$tag-${{ matrix.kind }}""
-        docker build . --file linux-x64.Dockerfile --tag "rhdpin/lazyfetcher:${{ matrix.kind }}""
+        docker build . --file $docker_file_name --tag "rhdpin/lazyfetcher:${{ matrix.kind }}""
         docker push "rhdpin/lazyfetcher:${{ matrix.kind }}""   
 
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,59 +5,53 @@ on:
     types: [published]
 
 jobs:
-  # github:
-  #   name: Publish and add binaries to release
-  #   strategy:
-  #     matrix: 
-  #       kind: ['linux-arm', 'linux-x64', 'windows', 'macOS']
-  #       include:
-  #         - kind: linux-arm
-  #           os: self-hosted
-  #           target: linux-arm
-  #         - kind: linux-x64
-  #           os: ubuntu-latest
-  #           target: linux-x64
-  #         - kind: windows
-  #           os: windows-latest
-  #           target: win-x64
-  #         - kind: macOS
-  #           os: macos-latest
-  #           target: osx-x64
-  #   runs-on: ${{ matrix.os }}  
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - name: Setup .NET
-  #     uses: actions/setup-dotnet@v1
-  #     with:
-  #       dotnet-version: 5.0.x
-  #   - name: Restore dependencies
-  #     run: dotnet restore src/
-  #   - name: Build
-  #     shell: bash
-  #     run: |
-  #       tag=$(git describe --tags --abbrev=0)
-  #       release_name="LazyFetcher-${{ matrix.target }}"
-  #       # Build everything
-  #       dotnet publish src/ --runtime "${{ matrix.target }}" -c Release -o "$release_name"
-  #       # Pack files
-  #       if [ "${{ matrix.target }}" == "win-x64" ]; then
-  #         # Pack to zip for Windows
-  #         7z a -tzip "${release_name}.zip" "./${release_name}/*"
-  #       else
-  #       tar czvf "${release_name}.tar.gz" "$release_name"
-  #       fi
-  #       # Delete output directory
-  #       rm -r "$release_name"
-  #   - name: Publish
-  #     uses: softprops/action-gh-release@v1
-  #     with:
-  #       files: "LazyFetcher*"
-  #     env:
-  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  github:
+    name: Publish binaries to release
+    strategy:
+      matrix: 
+        kind: ['linux-arm', 'linux-x64', 'windows', 'macOS']
+        include:
+          - kind: linux-arm
+            os: self-hosted
+            target: linux-arm
+          - kind: linux-x64
+            os: ubuntu-latest
+            target: linux-x64
+          - kind: windows
+            os: windows-latest
+            target: win-x64
+          - kind: macOS
+            os: macos-latest
+            target: osx-x64
+    runs-on: ${{ matrix.os }}  
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.x
+    - name: Restore dependencies
+      run: dotnet restore src/
+    - name: Build
+      shell: bash
+      run: |
+        tag=$(git describe --tags --abbrev=0)
+        release_name="LazyFetcher-${{ matrix.target }}"        
+        dotnet publish src/ --runtime "${{ matrix.target }}" -c Release -o "$release_name"        
+        if [ "${{ matrix.target }}" == "win-x64" ]; then
+          # Pack to zip for Windows
+          7z a -tzip "${release_name}.zip" "./${release_name}/*"
+        else
+        tar czvf "${release_name}.tar.gz" "$release_name"
+        fi        
+        rm -r "$release_name"
+    - name: Publish
+      uses: softprops/action-gh-release@v1
+      with:
+        files: "LazyFetcher*"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}   
     
-  #   #- name: Test
-  #   #  run: dotnet test --no-build --verbosity normal
-
   docker:
     name: Publish docker images
     strategy:
@@ -73,7 +67,7 @@ jobs:
     runs-on: ${{ matrix.os }}  
     steps:    
     - uses: actions/checkout@v2
-    - name: Login to DockerHub Registry
+    - name: Build and push the image
       shell: bash
       run: |
         echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin    

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,18 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build the Docker image
+      run: docker build . --file linux-x64.Dockerfile --tag rhdpin/lazystream:1.0.5-linux-x64

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Build
       run: dotnet publish -c release -r linux-arm src/           
     - name: Zip
-      run: tar -czvf -r linux-arm.zip src/bin/Release/netcoreapp3.1/linux-arm/publish
+      run: tar -czvf linux-arm.zip src/bin/Release/netcoreapp3.1/linux-arm/publish
     - uses: actions/upload-artifact@v2
       with:
         name: linux-arm

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         dotnet-version: 5.0.x
     - name: Restore dependencies
-      run: dotnet restore
+      run: dotnet restore src/
     - name: Build
       run: dotnet build --no-restore src/
     #- name: Test

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,92 +5,88 @@ on:
     types: [published]
 
 jobs:
-  release:
-    name: Release
+  # github:
+  #   name: Publish and add binaries to release
+  #   strategy:
+  #     matrix: 
+  #       kind: ['linux-arm', 'linux-x64', 'windows', 'macOS']
+  #       include:
+  #         - kind: linux-arm
+  #           os: self-hosted
+  #           target: linux-arm
+  #         - kind: linux-x64
+  #           os: ubuntu-latest
+  #           target: linux-x64
+  #         - kind: windows
+  #           os: windows-latest
+  #           target: win-x64
+  #         - kind: macOS
+  #           os: macos-latest
+  #           target: osx-x64
+  #   runs-on: ${{ matrix.os }}  
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - name: Setup .NET
+  #     uses: actions/setup-dotnet@v1
+  #     with:
+  #       dotnet-version: 5.0.x
+  #   - name: Restore dependencies
+  #     run: dotnet restore src/
+  #   - name: Build
+  #     shell: bash
+  #     run: |
+  #       tag=$(git describe --tags --abbrev=0)
+  #       release_name="LazyFetcher-${{ matrix.target }}"
+  #       # Build everything
+  #       dotnet publish src/ --runtime "${{ matrix.target }}" -c Release -o "$release_name"
+  #       # Pack files
+  #       if [ "${{ matrix.target }}" == "win-x64" ]; then
+  #         # Pack to zip for Windows
+  #         7z a -tzip "${release_name}.zip" "./${release_name}/*"
+  #       else
+  #       tar czvf "${release_name}.tar.gz" "$release_name"
+  #       fi
+  #       # Delete output directory
+  #       rm -r "$release_name"
+  #   - name: Publish
+  #     uses: softprops/action-gh-release@v1
+  #     with:
+  #       files: "LazyFetcher*"
+  #     env:
+  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    
+  #   #- name: Test
+  #   #  run: dotnet test --no-build --verbosity normal
+
+  docker:
+    name: Publish docker images
     strategy:
       matrix: 
-        kind: ['linux-arm', 'linux-x64', 'windows', 'macOS']
+        kind: ['linux-arm32v7', 'linux-x64']
         include:
-          - kind: linux-arm
+          - kind: linux-arm32v7
             os: self-hosted
             target: linux-arm
           - kind: linux-x64
             os: ubuntu-latest
-            target: linux-x64
-          - kind: windows
-            os: windows-latest
-            target: win-x64
-          - kind: macOS
-            os: macos-latest
-            target: osx-x64
+            target: linux-x64          
     runs-on: ${{ matrix.os }}  
-    steps:
+    steps:    
     - uses: actions/checkout@v2
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 5.0.x
-    - name: Restore dependencies
-      run: dotnet restore src/
-    - name: Build
-      shell: bash
+    - name: Login to DockerHub Registry
       run: |
+        echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin    
         tag=$(git describe --tags --abbrev=0)
-        release_name="LazyFetcher-${{ matrix.target }}"
-        # Build everything
-        dotnet publish src/ --runtime "${{ matrix.target }}" -c Release -o "$release_name"
-        # Pack files
-        if [ "${{ matrix.target }}" == "win-x64" ]; then
-          # Pack to zip for Windows
-          7z a -tzip "${release_name}.zip" "./${release_name}/*"
-        else
-        tar czvf "${release_name}.tar.gz" "$release_name"
-        fi
-        # Delete output directory
-        rm -r "$release_name"
-    - name: Publish
-      uses: softprops/action-gh-release@v1
-      with:
-        files: "LazyFetcher*"
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        docker_file_name = ""
+        if [ "${{ matrix.target }}" == "linux-x64" ]; then
+            docker_file_name = "linux-x64.Dockerfile"
+          else
+            docker_file_name = "linux-arm.Dockerfile"
+          fi
+        docker build . --file $docker_file_name --tag "rhdpin/lazyfetcher:$tag-${{ matrix.kind }}"
+        docker push "rhdpin/lazyfetcher:$tag-${{ matrix.kind }}""
+        docker build . --file linux-x64.Dockerfile --tag "rhdpin/lazyfetcher:${{ matrix.kind }}""
+        docker push "rhdpin/lazyfetcher:${{ matrix.kind }}""   
 
-    
-    #- name: Test
-    #  run: dotnet test --no-build --verbosity normal
-
-  # x64:
-  #   runs-on: ubuntu-latest
-
-  #   steps:    
-  #   - uses: actions/checkout@v2
-  #   - name: Login to DockerHub Registry
-  #     run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin    
-
-  #   - name: Build the tagged Docker image for linux-x64
-  #     run: docker build . --file linux-x64.Dockerfile --tag rhdpin/lazyfetcher:1.0.5-linux-x64
-  #   - name: Push the tagged Docker image for linux-x64
-  #     run: docker push rhdpin/lazyfetcher:1.0.5-linux-x64
-  #   - name: Build the latest Docker image for linux-x64
-  #     run: docker build . --file linux-x64.Dockerfile --tag rhdpin/lazyfetcher:linux-x64
-  #   - name: Push the latest Docker image for linux-x64
-  #     run: docker push rhdpin/lazyfetcher:linux-x64
-
-  # arm:
-  #   runs-on: self-hosted
-
-  #   steps:    
-  #   - uses: actions/checkout@v2
-  #   - name: Login to DockerHub Registry
-  #     run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin    
-
-  #   - name: Build the tagged Docker image for linux-arm
-  #     run: docker build . --file linux-arm.Dockerfile --tag rhdpin/lazyfetcher:1.0.5-linux-arm32v7
-  #   - name: Push the tagged Docker image for linux-arm
-  #     run: docker push rhdpin/lazyfetcher:1.0.5-linux-arm32v7
-  #   - name: Build the latest Docker image for linux-arm
-  #     run: docker build . --file linux-arm.Dockerfile --tag rhdpin/lazyfetcher:linux-arm32v7
-  #   - name: Push the latest Docker image for linux-arm
-  #     run: docker push rhdpin/lazyfetcher:linux-arm32v7
 
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -33,21 +33,21 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore src/
     - name: Build
-        shell: bash
-        run: |
-          tag=$(git describe --tags --abbrev=0)
-          release_name="LazyFetcher-${{ matrix.target }}"
-          # Build everything
-          dotnet publish src/ --runtime "${{ matrix.target }}" -c Release -o "$release_name"
-          # Pack files
-          if [ "${{ matrix.target }}" == "win-x64" ]; then
-            # Pack to zip for Windows
-            7z a -tzip "${release_name}.zip" "./${release_name}/*"
-          else
-          tar czvf "${release_name}.tar.gz" "$release_name"
-          fi
-          # Delete output directory
-          rm -r "$release_name"
+      shell: bash
+      run: |
+        tag=$(git describe --tags --abbrev=0)
+        release_name="LazyFetcher-${{ matrix.target }}"
+        # Build everything
+        dotnet publish src/ --runtime "${{ matrix.target }}" -c Release -o "$release_name"
+        # Pack files
+        if [ "${{ matrix.target }}" == "win-x64" ]; then
+          # Pack to zip for Windows
+          7z a -tzip "${release_name}.zip" "./${release_name}/*"
+        else
+        tar czvf "${release_name}.tar.gz" "$release_name"
+        fi
+        # Delete output directory
+        rm -r "$release_name"
     - name: Publish
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -78,13 +78,13 @@ jobs:
       run: |
         echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin    
         tag=$(git describe --tags --abbrev=0)
-        docker_file_name = ""
+        docker_file_name=""
         if [ "${{ matrix.target }}" == "linux-x64" ]; then
             docker_file_name = "linux-x64.Dockerfile"
           else
             docker_file_name = "linux-arm.Dockerfile"
           fi
-        docker build . --file $docker_file_name --tag "rhdpin/lazyfetcher:$tag-${{ matrix.kind }}"
+        docker build . --file "$docker_file_name" --tag "rhdpin/lazyfetcher:$tag-${{ matrix.kind }}"
         docker push "rhdpin/lazyfetcher:$tag-${{ matrix.kind }}""
         docker build . --file linux-x64.Dockerfile --tag "rhdpin/lazyfetcher:${{ matrix.kind }}""
         docker push "rhdpin/lazyfetcher:${{ matrix.kind }}""   

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -74,6 +74,7 @@ jobs:
     steps:    
     - uses: actions/checkout@v2
     - name: Login to DockerHub Registry
+      shell: bash
       run: |
         echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin    
         tag=$(git describe --tags --abbrev=0)

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,39 +7,55 @@ on:
     branches: [ master ]
 
 jobs:
+  build:
 
-  x64:
     runs-on: ubuntu-latest
 
-    steps:    
+    steps:
     - uses: actions/checkout@v2
-    - name: Login to DockerHub Registry
-      run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin    
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore src/
+    #- name: Test
+    #  run: dotnet test --no-build --verbosity normal
 
-    - name: Build the tagged Docker image for linux-x64
-      run: docker build . --file linux-x64.Dockerfile --tag rhdpin/lazyfetcher:1.0.5-linux-x64
-    - name: Push the tagged Docker image for linux-x64
-      run: docker push rhdpin/lazyfetcher:1.0.5-linux-x64
-    - name: Build the latest Docker image for linux-x64
-      run: docker build . --file linux-x64.Dockerfile --tag rhdpin/lazyfetcher:linux-x64
-    - name: Push the latest Docker image for linux-x64
-      run: docker push rhdpin/lazyfetcher:linux-x64
+  # x64:
+  #   runs-on: ubuntu-latest
 
-  arm:
-    runs-on: self-hosted
+  #   steps:    
+  #   - uses: actions/checkout@v2
+  #   - name: Login to DockerHub Registry
+  #     run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin    
 
-    steps:    
-    - uses: actions/checkout@v2
-    - name: Login to DockerHub Registry
-      run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin    
+  #   - name: Build the tagged Docker image for linux-x64
+  #     run: docker build . --file linux-x64.Dockerfile --tag rhdpin/lazyfetcher:1.0.5-linux-x64
+  #   - name: Push the tagged Docker image for linux-x64
+  #     run: docker push rhdpin/lazyfetcher:1.0.5-linux-x64
+  #   - name: Build the latest Docker image for linux-x64
+  #     run: docker build . --file linux-x64.Dockerfile --tag rhdpin/lazyfetcher:linux-x64
+  #   - name: Push the latest Docker image for linux-x64
+  #     run: docker push rhdpin/lazyfetcher:linux-x64
 
-    - name: Build the tagged Docker image for linux-arm
-      run: docker build . --file linux-arm.Dockerfile --tag rhdpin/lazyfetcher:1.0.5-linux-arm32v7
-    - name: Push the tagged Docker image for linux-arm
-      run: docker push rhdpin/lazyfetcher:1.0.5-linux-arm32v7
-    - name: Build the latest Docker image for linux-arm
-      run: docker build . --file linux-arm.Dockerfile --tag rhdpin/lazyfetcher:linux-arm32v7
-    - name: Push the latest Docker image for linux-arm
-      run: docker push rhdpin/lazyfetcher:linux-arm32v7
+  # arm:
+  #   runs-on: self-hosted
+
+  #   steps:    
+  #   - uses: actions/checkout@v2
+  #   - name: Login to DockerHub Registry
+  #     run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin    
+
+  #   - name: Build the tagged Docker image for linux-arm
+  #     run: docker build . --file linux-arm.Dockerfile --tag rhdpin/lazyfetcher:1.0.5-linux-arm32v7
+  #   - name: Push the tagged Docker image for linux-arm
+  #     run: docker push rhdpin/lazyfetcher:1.0.5-linux-arm32v7
+  #   - name: Build the latest Docker image for linux-arm
+  #     run: docker build . --file linux-arm.Dockerfile --tag rhdpin/lazyfetcher:linux-arm32v7
+  #   - name: Push the latest Docker image for linux-arm
+  #     run: docker push rhdpin/lazyfetcher:linux-arm32v7
 
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -16,13 +16,23 @@ jobs:
     - uses: actions/checkout@v2
     - name: Login to DockerHub Registry
       run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin    
-    - name: Build the tagged Docker image
+
+    - name: Build the tagged Docker image for linux-x64
       run: docker build . --file linux-x64.Dockerfile --tag rhdpin/lazyfetcher:1.0.5-linux-x64
-    - name: Push the tagged Docker image
+    - name: Push the tagged Docker image for linux-x64
       run: docker push rhdpin/lazyfetcher:1.0.5-linux-x64
-    - name: Build the latest Docker image
+    - name: Build the latest Docker image for linux-x64
       run: docker build . --file linux-x64.Dockerfile --tag rhdpin/lazyfetcher:linux-x64
-    - name: Push the latest Docker image
+    - name: Push the latest Docker image for linux-x64
       run: docker push rhdpin/lazyfetcher:linux-x64
+
+    - name: Build the tagged Docker image for linux-arm
+      run: docker build . --file linux-arm.Dockerfile --tag rhdpin/lazyfetcher:1.0.5-linux-arm32v7
+    - name: Push the tagged Docker image for linux-arm
+      run: docker push rhdpin/lazyfetcher:1.0.5-linux-arm32v7
+    - name: Build the latest Docker image for linux-arm
+      run: docker build . --file linux-arm.Dockerfile --tag rhdpin/lazyfetcher:linux-arm32v7
+    - name: Push the latest Docker image for linux-arm
+      run: docker push rhdpin/lazyfetcher:linux-arm32v7
 
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Echo
       run: echo $(pwd)
     - name: Zip
-      run: zip linux-x64.zip src/bin/Release/netcoreapp3.1/linux-x64/publish
+      run: zip -r linux-x64.zip src/bin/Release/netcoreapp3.1/linux-x64/publish
     - uses: actions/upload-artifact@v2
       with:
         name: linux.x64

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -12,7 +12,17 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    steps:
+    steps:    
     - uses: actions/checkout@v2
-    - name: Build the Docker image
-      run: docker build . --file linux-x64.Dockerfile --tag rhdpin/lazystream:1.0.5-linux-x64
+    - name: Login to DockerHub Registry
+      run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin    
+    - name: Build the tagged Docker image
+      run: docker build . --file linux-x64.Dockerfile --tag rhdpin/lazyfetcher:1.0.5-linux-x64
+    - name: Push the tagged Docker image
+      run: docker push rhdpin/lazyfetcher:1.0.5-linux-x64
+    - name: Build the latest Docker image
+      run: docker build . --file Dockerfile --tag rhdpin/lazyfetcher:linux-x64
+    - name: Push the latest Docker image
+      run: docker push rhdpin/lazyfetcher:linux-x64
+
+

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -80,9 +80,9 @@ jobs:
         tag=$(git describe --tags --abbrev=0)
         docker_file_name=""
         if [ "${{ matrix.target }}" == "linux-x64" ]; then
-            $docker_file_name="linux-x64.Dockerfile"
+            docker_file_name="linux-x64.Dockerfile"
           else
-            $docker_file_name="linux-arm.Dockerfile"
+            docker_file_name="linux-arm.Dockerfile"
           fi
         docker build . --file $docker_file_name --tag "rhdpin/lazyfetcher:$tag-${{ matrix.kind }}"
         docker push "rhdpin/lazyfetcher:$tag-${{ matrix.kind }}""

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -21,10 +21,12 @@ jobs:
       run: dotnet restore src/
     - name: Build
       run: dotnet publish -c release -r linux-x64 src/       
+    - name: Zip
+      run: zip linux-x64.zip src/bin/Release/netcoreapp3.1/linux-x64/publish
     - uses: actions/upload-artifact@v2
       with:
-        name: x64-binaries
-        path: src/**/linux-x64
+        name: linux.x64
+        path: linux-x64.zip
     #- name: Test
     #  run: dotnet test --no-build --verbosity normal
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A command-line interface for [LazyMan](https://github.com/StevensNJD4/LazyMan).
 * Download the latest game of given team
 * Get the stream URL to be used by a video player
 
-The application ([.NET Core 3.0](https://dotnet.microsoft.com/download/dotnet-core/3.0)) is basic with many fixed settings and supports only NHL feeds. See also similar (Rust made) application, [LazyStream](https://github.com/tarkah/lazystream). 
+The application ([.NET Core 3.1](https://dotnet.microsoft.com/download/dotnet-core/3.0)) is basic with many fixed settings and supports only NHL feeds. See also similar (Rust made) application, [LazyStream](https://github.com/tarkah/lazystream). 
 
 ## Requirements 
 * OS: Windows (x86/x64) / MacOS / Linux (x64/ARMv7)
@@ -23,7 +23,7 @@ If hosts file is not edited, [go-mlbam-proxy](https://github.com/jwallet/go-mlba
 Docker method is good because you get all done with one command. Currently the image size is big though (200-300MB). Currently it supports only 'hosts' editing approach, but the good thing is that it does not interfere with hosts file on your Docker host machine, but only the container.
 1. Install Docker on your host
 2. Run the container with command like: 
-`docker run -it --rm -v /mnt/download:/app/download --add-host targethostname:hostipaddress rhdpin/lazyfetcher:linux-x64 -c -p /app/download`
+`docker run -it --rm -v /mnt/download:/app/download --network=host --add-host targethostname:hostipaddress rhdpin/lazyfetcher:linux-x64 -c -p /app/download`
 
 Parameter `-v` binds a folder from host to container. In example command host folder is `/mnt/download` and it's mapped to `/app/download` in container. Parameter `--add-host` adds redirection to `hosts` file of the container, so replace `targethostname` and `hostipaddress` with same values which you use in `hosts` file with LazyMan. 
 
@@ -32,8 +32,7 @@ Parameter `-v` binds a folder from host to container. In example command host fo
 ## Usage
 ```
 $ ./LazyFetcher --help
-LazyFetcher 1.0.4
-Copyright (C) 2019 rhdpin
+LazyFetcher 1.0.5
 
   -c, --choose       Choose the feed from list of found feeds.
 
@@ -65,7 +64,7 @@ Copyright (C) 2019 rhdpin
 Choose the feed from list of found feeds and download it using proxy instead of editing hosts file
 ```
 $ ./LazyFetcher -x -c -p /mnt/download
-LazyFetcher 1.0.4
+LazyFetcher 1.0.5
 
  1: 2019-12-15 PHI@WPG home (TSN3)
  2: 2019-12-15 PHI@WPG away (NBCS-PH+)
@@ -94,7 +93,7 @@ Writing stream to file: 167 MB (11.8 MB/s)
 Get latest game of your favorite team with hosts file edited. It tries to get feed of chosen team (away/home) if available, otherwise it uses first feed found.
 ```
 $ ./LazyFetcher -t DAL -p /mnt/download
-LazyFetcher 1.0.4
+LazyFetcher 1.0.5
 
 Fetching latest feed for 'DAL'...
 Feed found: 2019-12-16 EDM@DAL (home,FSSW+)

--- a/linux-arm.Dockerfile
+++ b/linux-arm.Dockerfile
@@ -15,7 +15,7 @@ RUN dotnet restore
 WORKDIR /app/
 COPY src/. ./src/
 WORKDIR /app/src
-RUN dotnet publish -c Release -o out
+RUN dotnet publish -r linux-arm -c Release -o out
 
 FROM mcr.microsoft.com/dotnet/runtime:3.1-bionic-arm32v7 as runtime
 WORKDIR /app

--- a/nuget.config
+++ b/nuget.config
@@ -6,7 +6,7 @@
 	<trustedSigners>
 <repository name="nuget.org" serviceIndex="https://api.nuget.org/v3/index.json">
             <certificate fingerprint="0E5F38F57DC1BCC806D8494F4F90FBCEDD988B46760709CBEEC6F4219AA6157D" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
-            <owners>microsoft;aspnet;nuget</owners>
+            <owners>microsoft;aspnet;nuget;newtonsoft</owners>
         </repository>
   <author name="Microsoft">
     <certificate fingerprint="3F9001EA83C560D712C24CF213C3D312CB3BFF51EE89435D3430BD06B5D0EECE" hashAlgorithm="SHA256" allowUntrustedRoot="true" />

--- a/nuget.config
+++ b/nuget.config
@@ -1,1 +1,1 @@
-<config> <add key=”signatureValidationMode” value=”accept” />
+<config> <add key="signatureValidationMode" value="accept" />

--- a/nuget.config
+++ b/nuget.config
@@ -1,1 +1,3 @@
-<config> <add key="signatureValidationMode" value="accept" />
+<config> 
+<add key="signatureValidationMode" value="accept" />
+</config>

--- a/nuget.config
+++ b/nuget.config
@@ -1,3 +1,7 @@
-<config> 
-<add key="signatureValidationMode" value="accept" />
-</config>
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <config>
+	<add key="signatureValidationMode" value="accept" />
+    </config>
+</configuration>
+

--- a/nuget.config
+++ b/nuget.config
@@ -6,7 +6,6 @@
 	<trustedSigners>
 <repository name="nuget.org" serviceIndex="https://api.nuget.org/v3/index.json">
             <certificate fingerprint="0E5F38F57DC1BCC806D8494F4F90FBCEDD988B46760709CBEEC6F4219AA6157D" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
-            <owners>microsoft;aspnet;nuget;newtonsoft</owners>
         </repository>
   <author name="Microsoft">
     <certificate fingerprint="3F9001EA83C560D712C24CF213C3D312CB3BFF51EE89435D3430BD06B5D0EECE" hashAlgorithm="SHA256" allowUntrustedRoot="true" />

--- a/nuget.config
+++ b/nuget.config
@@ -5,7 +5,9 @@
     </config>
 	<trustedSigners>
 <repository name="nuget.org" serviceIndex="https://api.nuget.org/v3/index.json">
-  </repository>
+            <certificate fingerprint="0E5F38F57DC1BCC806D8494F4F90FBCEDD988B46760709CBEEC6F4219AA6157D" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
+            <owners>microsoft;aspnet;nuget</owners>
+        </repository>
   <author name="Microsoft">
     <certificate fingerprint="3F9001EA83C560D712C24CF213C3D312CB3BFF51EE89435D3430BD06B5D0EECE" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
     <certificate fingerprint="AA12DA22A49BCE7D5C1AE64CC1F3D892F150DA76140F210ABD2CBFFCA2C18A27" hashAlgorithm="SHA256" allowUntrustedRoot="true" />

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,1 @@
+<config> <add key=”signatureValidationMode” value=”accept” />

--- a/nuget.config
+++ b/nuget.config
@@ -3,5 +3,11 @@
     <config>
 	<add key="signatureValidationMode" value="accept" />
     </config>
+	<trustedSigners>
+  <author name="Microsoft">
+    <certificate fingerprint="3F9001EA83C560D712C24CF213C3D312CB3BFF51EE89435D3430BD06B5D0EECE" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
+    <certificate fingerprint="AA12DA22A49BCE7D5C1AE64CC1F3D892F150DA76140F210ABD2CBFFCA2C18A27" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
+  </author>
+</trustedSigners>
 </configuration>
 

--- a/nuget.config
+++ b/nuget.config
@@ -4,6 +4,8 @@
 	<add key="signatureValidationMode" value="accept" />
     </config>
 	<trustedSigners>
+<repository name="nuget.org" serviceIndex="https://api.nuget.org/v3/index.json">
+  </repository>
   <author name="Microsoft">
     <certificate fingerprint="3F9001EA83C560D712C24CF213C3D312CB3BFF51EE89435D3430BD06B5D0EECE" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
     <certificate fingerprint="AA12DA22A49BCE7D5C1AE64CC1F3D892F150DA76140F210ABD2CBFFCA2C18A27" hashAlgorithm="SHA256" allowUntrustedRoot="true" />


### PR DESCRIPTION
Publish the binaries when new release is made. Binaries are added in release and docker images are pushed to Docker Hub. Nuget.config was added to skip signature checks due to certificate issues occurring when building Docker images.